### PR TITLE
Debug Followup

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -109,7 +109,10 @@ const MoreButton = styled.button`
 
 export const query = graphql`
   query {
-    allWpPost(filter: { categories: { nodes: { elemMatch: { slug: { eq: "episodes" } } } } }) {
+    allWpPost(
+      sort: { fields: date, order: DESC }
+      filter: { categories: { nodes: { elemMatch: { slug: { eq: "episodes" } } } } }
+    ) {
       edges {
         node {
           id

--- a/src/pages/transcripts.js
+++ b/src/pages/transcripts.js
@@ -52,7 +52,10 @@ export default TagIndexPage
 
 export const query = graphql`
   query {
-    allWpPost(filter: { categories: { nodes: { elemMatch: { slug: { eq: "transcripts" } } } } }) {
+    allWpPost(
+      sort: { fields: date, order: DESC }
+      filter: { categories: { nodes: { elemMatch: { slug: { eq: "transcripts" } } } } }
+    ) {
       edges {
         node {
           id

--- a/src/templates/tagIndex.js
+++ b/src/templates/tagIndex.js
@@ -47,8 +47,11 @@ TagIndexPage.propTypes = propTypes
 export default TagIndexPage
 
 export const query = graphql`
-  query($tag: String) {
-    allWpPost(filter: { tags: { nodes: { elemMatch: { slug: { eq: $tag } } } } }) {
+  query ($tag: String) {
+    allWpPost(
+      sort: { fields: date, order: DESC }
+      filter: { tags: { nodes: { elemMatch: { slug: { eq: $tag } } } } }
+    ) {
       edges {
         node {
           id


### PR DESCRIPTION
The Green New Deal follow-up was somehow last in the post order. Either there was something special about it or date sorting could not be guaranteed but the default query. Regardless, now query results are sorted by date.